### PR TITLE
Assign repos to responsible components (and so also leads)

### DIFF
--- a/Components.md
+++ b/Components.md
@@ -12,30 +12,50 @@
 Configuration:
 
 - catalogue-data
-- catalogue-supported-data
-- element84-data
-- stac-harvester-configurations
+- catalogue-supported-data (Hannah Collingwood)
+- element84-data (Hannah Collingwood)
+- stac-harvester-configurations (Hannah Collingwood)
 - test-catalogue-data
+- user-data-catalogue
 
 Code:
 
+- annotations-ingester (Alex Hayward)
+- annotations-service (Alex Hayward)
+- annotations-transformer
 - catalogue-search-service
-- configscanning
-- eodhp-git-change-scanner
-- eodhp-utils
+- commercial-data-adaptors
+- configscanning (Hannah Collingwood)
+- eodhp-git-change-scanner (Hannah Collingwood)
+- git-change-scanner (OBSOLETE) (Alex Hayward)
+- eodhp-utils (Hannah Collingwood)
 - eodhp-workflow-transformer
 - harvest-transformer
+- harvest-error-notifier (Hannah Collingwood)
+- resource-catalogue-fastapi (Alex Palmer)
 - stac-fastapi
 - stac-fastapi-elasticsearch-opensearch
 - stac-fastapi-ingester
-- stac-harvester
-- stac-harvester-ingester
+- stac-harvester (Hannah Collingwood)
+- stac-harvester-ingester (Hannah Collingwood)
+- workspace-catalog-generator
+- UKEODHP/catalogue-search-service-temp
+- UKEODHP/eodhp-init-catalogs-harvest
+- UKEODHP/stac-fastapi-data-loader
 
 ## Workflow and Analysis System
 
 ### Lead Developer
 
 - Jonny Langstone
+
+### Repositories
+
+- eodhp-workspace-controller
+- eodhp-workspace-manager
+- eodhp-workspace-services
+- UKEODHP/apphub-singleuser
+- UKEODHP/workspace-controller-testenv
 
 ## Workflow Runner
 
@@ -47,14 +67,27 @@ Code:
 
 Code:
 
+- ades-fastapi
+- ades-workflow-examples
 - eodhp-ades-demonstration
 - eodhp-ades-workspace-access
+- generate-annotations-workflow
 - eoepca-proc-service-template
 - stac-workflow-generator
+- test-workflow-store
+- workflow-ingester
+- UKEODHP/ades-auth-proxy (Steven Gillies)
+- UKEODHP/ades-stagein
+- UKEODHP/ades-stageout
+- UKEODHP/calrissian
+- UKEODHP/pycalrissian
+- UKEODHP/zoo-calrissian-runner
+- UKEODHP/ZOO-Project
 
 Configuration:
 
 - public-workflows
+- user-workflows-catalogue-dev
 
 ## Data Access Services
 
@@ -67,15 +100,30 @@ Configuration:
 Code:
 
 - eodhp-convert-netcdf
+- titiler-stacapi
+- titiler-xarray
+- UKEODHP/eodhp-eoxserver (OBSOLETE)
+- UKEODHP/eodhp-eoxserver-climate-data (OBSOLETE)
+- UKEODHP/eodhp-eoxserver-django (OBSOLETE)
+- UKEODHP/eodhp-eoxserver-netcdf-demo (OBSOLETE)
+- UKEODHP/eodhp-eoxviewserver (OBSOLETE)
+- UKEODHP/eoxserver (OBSOLETE)
+- UKEODHP/eoxviewserver-demo (OBSOLETE)
+- UKEODHP/eoxvs-register-stac-items (OBSOLETE)
+- UKEODHP/titiler-stacapi
 
 ## Data Streams
 
 ### Lead Developer
 
 - Alex Palmer
-- Mark Small (UI)
 
 ### Repositories
+
+Code:
+
+- airbus-harvester
+- planet-harvester (Hannah Collingwood)
 
 ## Web Presence
 
@@ -89,6 +137,8 @@ Code:
 Code:
 
 - eodhp-web-presence
+- eodhp-workspace-ui (James Hinton)
+- react-starter-app (James Hinton)
 
 Configuration:
 
@@ -114,22 +164,23 @@ Code:
 - Steven Gillies
 - Jonny Langstone
 
-## Event Notification Service
-
-### Lead Developer
-
-- Hannah Collingwood
-
 ### Repositories
 
 Code:
 
 - eodh-demo-client-app
+- eodhp-auth-agent
+- keycloak-offline-token
 
 Configuration:
 
-- eodhp-opa-config-dev
-- eodhp-opa-config-test
+- eodhp-opa-config
+
+## Event Notification Service
+
+### Lead Developer
+
+- Hannah Collingwood
 
 ## System Management
 
@@ -145,10 +196,14 @@ Configuration:
 - eodhp-deploy-infrastucture
 - eodhp-deploy-supporting-infrastructure
 - eodhp-workspaces
+- UKEODHP/argocd-autopilot-reference-deployment (OBSOLETE)
+- UKEODHP/eck-stack
+- UKEODHP/linkerd-demo
+- UKEODHP/pulsar-demo (OBSOLETE)
 
 Code:
 
-- github-actions
+- github-actions (Hannah Collingwood)
 
 ## Testing
 
@@ -156,9 +211,39 @@ Code:
 
 - Alex Palmer
 
+### Repositories
+
+Code:
+
+- resource-catalogue-tests
+- workflow-system-test (Tom Jellicoe)
+- UKEODHP/argo-workflow-system-tests
+- UKEODHP/public-workflows-test (Tom Jellicoe)
+- UKEODHP/resource-catalogue-tests (Hannah Collingwood)
+
+## Other
+
+### Repositories
+
+Documentation:
+
+- documentation (Alex Hayward)
+- eodhp-guide (Steven Gillies)
+- eodhp-sprint-reports (Steven Gillies)
+- UKEODHP/eodhp-system-tests-tradeoff (OBSOLETE)
+- UKEODHP/system-test-tradeoff (OBSOLETE)
+- UKEODHP/template-python (Alex Hayward)
+
 # Lead Responsibilities
 
-A lead might not do all (or even most) development on a component but should
+A lead might not do all (or even most) development on a component but should help plan the
+functional and architectural evolution of the component - developing or writing user stories,
+for example.
 
-- Help plan the functional and architectural evolution of the component - developing or writing user stories, for example.
-- Be responsible for maintenance of the component and repos that aren't for particular stories. That includes updating dependencies, picking up security alerts and creating tags/packages/builds/... when we're making a release.
+A lead is also responsible for the repositories for that component unless otherwise listed.
+Except for those marked OBSOLETE, the person responsible should:
+
+- Watch the repository for at least security alerts and respond to them.
+- Keep dependencies up-to-date or keeping it up-to-date with an upstream repo it was forked from.
+- Keep the build system running and up-to-date.
+- Do any other maintenance of the repo that isn't a part of particular stories.

--- a/Components.md
+++ b/Components.md
@@ -16,7 +16,6 @@ Configuration:
 - stac-harvester-configurations
 - test-catalogue-data
 
-
 Code:
 - catalogue-search-service
 - configscanning
@@ -29,7 +28,6 @@ Code:
 - stac-fastapi-ingester
 - stac-harvester
 - stac-harvester-ingester
-
 
 
 ## Workflow and Analysis System
@@ -52,7 +50,6 @@ Code:
 - eodhp-ades-workspace-access
 - eoepca-proc-service-template
 - stac-workflow-generator
-
 
 Configuration:
 
@@ -101,6 +98,7 @@ Code:
 - eodhp-resource-catalogue-ui
 - stac-browser
 
+
 ## IAM
 
 ### Lead Developer
@@ -117,7 +115,6 @@ Configuration:
 
 - eodhp-opa-config-dev
 - eodhp-opa-config-test
-
 
 
 ## System Management

--- a/Components.md
+++ b/Components.md
@@ -6,6 +6,32 @@
 
 - Alex Palmer
 
+### Repositories
+
+Configuration:
+
+- catalogue-data
+- catalogue-supported-data
+- element84-data
+- stac-harvester-configurations
+- test-catalogue-data
+
+
+Code:
+- catalogue-search-service
+- configscanning
+- eodhp-git-change-scanner
+- eodhp-utils
+- eodhp-workflow-transformer
+- harvest-transformer
+- stac-fastapi
+- stac-fastapi-elasticsearch-opensearch
+- stac-fastapi-ingester
+- stac-harvester
+- stac-harvester-ingester
+
+
+
 ## Workflow and Analysis System
 
 ### Lead Developer
@@ -18,11 +44,33 @@
 
 - Tom Jellicoe
 
+### Repositories
+
+Code:
+
+- eodhp-ades-demonstration
+- eodhp-ades-workspace-access
+- eoepca-proc-service-template
+- stac-workflow-generator
+
+
+Configuration:
+
+- public-workflows
+
+
 ## Data Access Services
 
 ### Lead Developer
 
 - James Hinton
+
+### Repositories
+
+Code:
+
+- eodhp-convert-netcdf
+
 
 ## Web Presence
 
@@ -30,11 +78,47 @@
 
 - Hannah Collingwood
 
+### Repositories
+
+Code:
+
+- eodhp-web-presence
+
+Configuration:
+
+- eodhp-web-presence-helm
+
+
+## Catalogue UI
+
+### Lead Developer
+
+- James Hinton
+
+### Repositories
+
+Code:
+- eodhp-resource-catalogue-ui
+- stac-browser
+
 ## IAM
 
 ### Lead Developer
 
 - Steven Gillies
+
+### Repositories
+
+Code:
+
+- eodh-demo-client-app
+
+Configuration:
+
+- eodhp-opa-config-dev
+- eodhp-opa-config-test
+
+
 
 ## System Management
 
@@ -42,8 +126,30 @@
 
 - Steven Gillies
 
+### Repositories
+
+Configuration:
+
+- eodhp-argocd-deployment
+- eodhp-deploy-infrastucture
+- eodhp-deploy-supporting-infrastructure
+- eodhp-workspaces
+
+Code:
+
+- github-actions
+
+
 ## Testing
 
 ### Lead Developer
 
-- Serkan Dural
+- ~~Serkan Dural~~
+
+
+# Lead Responsibilities
+
+A lead might not do all (or even most) development on a component but should
+
+* Help plan the functional and architectural evolution of the component - developing or writing user stories, for example.
+* Be responsible for maintenance of the component and repos that aren't for particular stories. That includes updating dependencies, picking up security alerts and creating tags/packages/builds/... when we're making a release.


### PR DESCRIPTION
This adds a list of repos to each component. The motivation is to have a particular person responsible for dependency updates and monitoring security alerts.