### PR TITLE
added initial iam scope design

### DIFF
--- a/Platform IAM.md
+++ b/Platform IAM.md
@@ -1,0 +1,125 @@
+# Platform IAM
+
+## OIDC Clients
+
+### eodh (Formerly oauth2-proxy)
+
+The `eodh` client is responsible for all platform authentication on the eodatahub.org.uk domain.
+
+#### Supported Authentication Flows
+
+- Standard flow
+- Direct access grants
+
+#### Scopes
+
+**Default Scopes**
+
+- openid
+- profile
+
+**Optional Scopes**
+
+- groups
+- roles
+
+### eodh-workspaces (Formerly oauth2-proxy-workspaces)
+
+The `eodh-workspaces` client is responsible for all workspace authentication, including authorisation on the eodatahub-workspaces.org.uk domain.
+
+#### Supported Authentication Flows
+
+- Standard flow
+- Direct access grants
+- Service account roles
+
+#### Scopes
+
+**Default Scopes**
+
+- openid
+- profile
+
+**Optional Scopes**
+
+- groups
+- roles
+- workspaces
+- workspace:${workspace}
+
+## Scopes
+
+**openid**
+This is the default scope returned as a baseline by all OIDC clients.
+
+```
+{
+  "exp": 1736243921,
+  "iat": 1736243621,
+  "jti": "f2b9b23a-b4d0-4883-a37c-10e207c0122d",
+  "iss": "https://eodatahub.org.uk/keycloak/realms/eodhp",
+  "typ": "Bearer",
+  "azp": "eodh",
+  "sid": "2be73a8c-37cb-4926-a482-43d9cfe07520",
+  "scope": ""
+}
+```
+
+**profile**
+This scope provides user info and should normally be provided as default by most OIDC clients.
+
+```
+{
+  ...
+  "name": "Steven Gillies",
+  "preferred_username": "sgillies-tpzuk",
+  "given_name": "Steven",
+  "family_name": "Gillies",
+}
+```
+
+**groups**
+This scope provides the Keycloak groups that a user is a member of.
+
+```
+{
+  ...
+  "groups": ["group1", "group2"]
+}
+```
+
+**roles**
+This scope provides the Keycloak roles that a group is permitted for.
+
+```
+{
+  ...
+  "roles": ["role1", "role2"]
+}
+```
+
+**workspaces**
+This scope provides available workspaces without setting the active workspace.
+
+```
+{
+  ...
+  "workspaces": {
+    "active": null,
+    "available": ["workspace1", "workspace2"]
+  }
+}
+```
+
+**workspaces:${workspace}**
+This is a dynamic scope that will return an active workspace, if authorised. The available workspaces are included with this as well. The desired active workspace is passed as part of the token request as a dynamic scope parameter after the ':'.
+
+```
+{
+  ...
+  "workspaces": {
+    "active": "workspace1",
+    "available": ["workspace1", "workspace2"]
+  }
+}
+```

--- a/Platform IAM.md
+++ b/Platform IAM.md
@@ -72,10 +72,10 @@ This scope provides user info and should normally be provided as default by most
 ```
 {
   ...
-  "name": "Steven Gillies",
-  "preferred_username": "sgillies-tpzuk",
-  "given_name": "Steven",
-  "family_name": "Gillies",
+  "name": "Joe Bloggs",
+  "preferred_username": "jbloggs",
+  "given_name": "Joe",
+  "family_name": "Bloggs",
 }
 ```
 

--- a/Platform IAM.md
+++ b/Platform IAM.md
@@ -46,6 +46,7 @@ The `eodh-workspaces` client is responsible for all workspace authentication, in
 - roles
 - workspaces
 - workspace:${workspace}
+- user_service:${user_service}
 
 ## Scopes
 
@@ -112,7 +113,9 @@ This scope provides available workspaces without setting the active workspace.
 ```
 
 **workspaces:${workspace}**
-This is a dynamic scope that will return an active workspace, if authorised. The available workspaces are included with this as well. The desired active workspace is passed as part of the token request as a dynamic scope parameter after the ':'.
+This is a dynamic scope that will return the active workspace, if authorised. The available workspaces are included with this as well. The desired active workspace is passed as part of the token request as a dynamic scope parameter after the ':'.
+
+The scope also contains an additional AWS scope to allow for parameterised AWS policies when using `assumeRoleWithWebIdentity` using principal tags.
 
 ```
 {
@@ -120,6 +123,30 @@ This is a dynamic scope that will return an active workspace, if authorised. The
   "workspaces": {
     "active": "workspace1",
     "available": ["workspace1", "workspace2"]
+  },
+  "https://aws.amazon.com/tags": {
+    "principal_tags": {
+      "workspaces": ["workspace1"]
+    }
+  }
+}
+```
+
+**user_service:${user_service}**
+This is a dynamic scope that will return the active user_service. There is no additional authorisation required for this.
+
+The scope also contains an additional AWS scope to allow for parameterised AWS policies when using `assumeRoleWithWebIdentity` using principal tags.
+
+```
+{
+  ...
+  "workspaces": {
+    "user_service": "user_service1"
+  },
+  "https://aws.amazon.com/tags": {
+    "principal_tags": {
+      "user_services": ["user_service1"]
+    }
   }
 }
 ```

--- a/Platform IAM.md
+++ b/Platform IAM.md
@@ -125,7 +125,7 @@ This scope provides available workspaces without setting the active workspace.
 ```
 
 **workspaces:${workspace}**
-This is a dynamic scope that will return the active workspace, if authorised. The available workspaces are included with this as well. The desired active workspace is passed as part of the token request as a dynamic scope parameter after the ':'.
+This is a dynamic scope that will return the active workspace, if authorised. The available workspaces are included with this as well. The desired active workspace is passed as part of the token request as a dynamic scope parameter after the ':'. Available workspaces will be cut down to only include the active workspace. The fields are kept separate so that behaviour based on active workspaces can be separated from bahviour that can work with multiple workspaces.
 
 The scope also contains an additional AWS scope to allow for parameterised AWS policies when using `assumeRoleWithWebIdentity` using principal tags.
 
@@ -134,7 +134,7 @@ The scope also contains an additional AWS scope to allow for parameterised AWS p
   ...
   "workspaces": {
     "active": "workspace1",
-    "available": ["workspace1", "workspace2"]
+    "available": ["workspace1"]
   },
   "https://aws.amazon.com/tags": {
     "principal_tags": {

--- a/Platform IAM.md
+++ b/Platform IAM.md
@@ -17,6 +17,7 @@ The `eodh` client is responsible for all platform authentication on the eodatahu
 
 - openid
 - profile
+- aud
 
 **Optional Scopes**
 
@@ -39,6 +40,7 @@ The `eodh-workspaces` client is responsible for all workspace authentication, in
 
 - openid
 - profile
+- aud
 
 **Optional Scopes**
 
@@ -76,6 +78,16 @@ This scope provides user info and should normally be provided as default by most
   "preferred_username": "jbloggs",
   "given_name": "Joe",
   "family_name": "Bloggs",
+}
+```
+
+**aud**
+The audience of clients to which the access token can be used.
+
+```
+{
+  ...
+  "aud": ["client1", "client2"]
 }
 ```
 


### PR DESCRIPTION
PR to agree an OIDC scope design. Before I was familiar enough with Keycloak scope configuration I just used the built in Keycloak scopes, but these add needless layers to the scope (specifically the standard "role" scope) or were named strangely ("member_groups" instead of simply groups).

Workspace related scopes evolved to be "workspace:${workspace}" and "workspaces" in the scope root, which is a bit unclear. Instead, both have been nested under "workspaces" and given more meaningful fields ("active" and "available"), which should increase developer understanding. "workspace:${workspace}" and "workspaces" have been aligned in what they return so that the fields present are more predictable and do not need to be tested for before checking. "workspaces.active" will be null for "workspaces" scope, and "workspaces.available" will always be returned as part of "workspaces:${workspace}" to avoid the need to request scope "workspaces workspace:${workspace}".

"user_service" was also nested under "workspace" scope object, but is only optional.

AWS principal tags have been added to both dynamic scopes for use with AWS principal tags.