### PR TITLE
Update endpoints for new public, commercial and user catalogs

### DIFF
--- a/examples/uc9-data-discovery-and-analysis/data-discovery.ipynb
+++ b/examples/uc9-data-discovery-and-analysis/data-discovery.ipynb
@@ -549,10 +549,10 @@
     "from pystac_client import Client\n",
     "\n",
     "# Set resource catalogue top-level url\n",
-    "rc_url = f\"https://{platform_domain}/api/catalogue/stac/catalogs/supported-datasets\"\n",
+    "rc_url = f\"https://{platform_domain}/api/catalogue/stac/catalogs/public\"\n",
     "\n",
     "# We can also view the STAC Catalogue using STAC Browser here \n",
-    "# https://staging.eodatahub.org.uk/static-apps/stac-browser/main/index.html#/external/staging.eodatahub.org.uk/api/catalogue/stac/catalogs/supported-datasets\n",
+    "# https://staging.eodatahub.org.uk/static-apps/stac-browser/main/index.html#/external/staging.eodatahub.org.uk/api/catalogue/stac/catalogs/public\n",
     "\n",
     "# Create STAC client\n",
     "stac_client = Client.open(rc_url)"
@@ -637,7 +637,7 @@
     "children = stac_client.get_children()\n",
     "\n",
     "for child in children:\n",
-    "    if child.id == \"ceda-stac-catalogue\":\n",
+    "    if child.id == \"stac-fastapi\":\n",
     "        ceda_catalog = child\n",
     "        break\n",
     "\n",
@@ -666,10 +666,10 @@
     "from pystac_client import Client\n",
     "\n",
     "# Set resource catalogue top-level url\n",
-    "rc_url = f\"https://{platform_domain}/api/catalogue/stac/catalogs/user-datasets\"\n",
+    "rc_url = f\"https://{platform_domain}/api/catalogue/stac/catalogs/user\"\n",
     "\n",
     "# We can also view the STAC Catalogue using STAC Browser here \n",
-    "# https://staging.eodatahub.org.uk/static-apps/stac-browser/main/index.html#/external/staging.eodatahub.org.uk/api/catalogue/stac/catalogs/user-datasets\n",
+    "# https://staging.eodatahub.org.uk/static-apps/stac-browser/main/index.html#/external/staging.eodatahub.org.uk/api/catalogue/stac/catalogs/user\n",
     "\n",
     "# Create STAC client without authentication\n",
     "stac_client = Client.open(rc_url)"
@@ -812,7 +812,7 @@
     "from pystac_client import Client\n",
     "\n",
     "# Set resource catalogue top-level url\n",
-    "rc_url = f\"https://{platform_domain}/api/catalogue/stac/catalogs/supported-datasets/catalogs/planet\"\n",
+    "rc_url = f\"https://{platform_domain}/api/catalogue/stac/catalogs/commercial/catalogs/planet\"\n",
     "\n",
     "# Create STAC client without authentication\n",
     "stac_client = Client.open(rc_url)"
@@ -1029,7 +1029,7 @@
    "source": [
     "import requests\n",
     "\n",
-    "url = f\"https://{platform_domain}/api/catalogue/manage/catalogs/user-datasets/{workspace}/commercial-data\"\n",
+    "url = f\"https://{platform_domain}/api/catalogue/manage/catalogs/user/{workspace}/commercial-data\"\n",
     "headers = {\n",
     "    \"accept\": \"application/json\", \n",
     "    \"Content-Type\": \"application/json\", \n",
@@ -1178,7 +1178,7 @@
    "source": [
     "import requests\n",
     "\n",
-    "url = f\"https://{platform_domain}/api/catalogue/manage/catalogs/user-datasets/{workspace}/commercial-data\"\n",
+    "url = f\"https://{platform_domain}/api/catalogue/manage/catalogs/user/{workspace}/commercial-data\"\n",
     "headers = {\n",
     "    \"accept\": \"application/json\", \n",
     "    \"Content-Type\": \"application/json\", \n",
@@ -1248,7 +1248,7 @@
     "from pystac_client import Client\n",
     "\n",
     "# Set resource catalogue top-level url\n",
-    "rc_url = f\"https://{platform_domain}/api/catalogue/stac/catalogs/supported-datasets/catalogs/planet\"\n",
+    "rc_url = f\"https://{platform_domain}/api/catalogue/stac/catalogs/commercial/catalogs/planet\"\n",
     "\n",
     "# Create STAC client without authentication\n",
     "stac_client = Client.open(rc_url)\n",
@@ -1363,7 +1363,7 @@
    "source": [
     "import requests\n",
     "\n",
-    "url = f'https://{platform_domain}/api/catalogue/manage/catalogs/user-datasets/{workspace}/commercial-data'\n",
+    "url = f'https://{platform_domain}/api/catalogue/manage/catalogs/user/{workspace}/commercial-data'\n",
     "headers = {\n",
     "    'accept': 'application/json', \n",
     "    'Content-Type': 'application/json', \n",
@@ -1380,7 +1380,7 @@
     "print(\"Status Code\", response.status_code)\n",
     "print(\"Response \", response.json())\n",
     "\n",
-    "print(f\"https://{platform_domain}/api/catalogue/stac/catalogs/user-datasets/catalogs/{workspace}/catalogs/commercial-data/catalogs/planet/catalogs\")"
+    "print(f\"https://{platform_domain}/api/catalogue/stac/catalogs/user/catalogs/{workspace}/catalogs/commercial-data/catalogs/planet/catalogs\")"
    ]
   },
   {
@@ -1412,7 +1412,7 @@
     "# we can view them in the resource catalogue, once delivered\n",
     "\n",
     "# We first need to create a pystac client instance with authentication\n",
-    "rc_url = f\"https://{platform_domain}/api/catalogue/stac/catalogs/user-datasets/catalogs/{workspace}\"\n",
+    "rc_url = f\"https://{platform_domain}/api/catalogue/stac/catalogs/user/catalogs/{workspace}\"\n",
     "\n",
     "# Create STAC client\n",
     "stac_client = Client.open(rc_url, headers={\"Authorization\": f\"Bearer {token}\"})\n",
@@ -1791,7 +1791,7 @@
     "print(f\"Job status is finally {job.status}\")\n",
     "job_id = job.id\n",
     "\n",
-    "catalog_href = f\"https://staging.eodatahub.org.uk/api/catalogue/stac/catalogs/user-datasets/catalogs/{workspace}/catalogs/processing-results/catalogs/cat_{job_id}\""
+    "catalog_href = f\"https://staging.eodatahub.org.uk/api/catalogue/stac/catalogs/user/catalogs/{workspace}/catalogs/processing-results/catalogs/cat_{job_id}\""
    ]
   },
   {
@@ -1825,7 +1825,7 @@
     "# we can view them in the resource catalogue, once delivered\n",
     "\n",
     "# We first need to create a pystac client instance with authentication\n",
-    "rc_url = f\"https://{platform_domain}/api/catalogue/stac/catalogs/user-datasets/catalogs/{workspace}/catalogs/processing-results\"\n",
+    "rc_url = f\"https://{platform_domain}/api/catalogue/stac/catalogs/user/catalogs/{workspace}/catalogs/processing-results\"\n",
     "\n",
     "# Create STAC client\n",
     "stac_client = Client.open(rc_url, headers={\"Authorization\": f\"Bearer {token}\"})\n",
@@ -2024,7 +2024,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.9.21"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Update docs for new resource catalog top-level catalogs
- Swapped `supported-datasets` for `public` and `commercial`
- Swapped `user-datasets` for `user`
- Updated ID for ceda stac catalogue to match it's latest harvested name